### PR TITLE
Update certificate docs and transfer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,49 +19,62 @@ These certificates are essential for securing communication between OpenWiFi com
 
 ## Steps to Generate Certificates
 **Update certificate subject fields**
-   Before running the scripts, update the subject fields to match your environment:
-   - Root CA: conf/rootca.cnf
-   - Issuer CA: conf/issuer.cnf
-   - Server cert: conf/server.cnf
 
-   Ensure values like commonName, countryName, and stateOrProvinceName are correct.
+   Before running the scripts, update the certificate subject fields to match your environment.
 
-1. **Create Root CA**
+   Verify these values are correct where applicable: `commonName`, `countryName`, `stateOrProvinceName` and `organizationName`.
+
+   Update the following files:
+   - Root CA: `conf/rootca.cnf`
+   - Issuer CA: `conf/issuer.cnf`
+   - Client certificate: `conf/client.cnf`
+
+
+ **Create Root CA**
    Run the script to generate the Root Certificate Authority:
    ```bash
    ./createRootCA.sh
    ```
 
-2. **Create Issuer CA**
+ **Create Issuer CA**
    Generate the Issuer CA signed by the Root CA:
    ```bash
    ./createIssuer.sh
    ```
 
-3. **Generate Server Certificate**
+ **Generate Server Certificate**
+
    Create the server's private key and certificate:
+
+   Make sure `commonName` is set to your actual domain name in: `conf/server.cnf`
    ```bash
    ./createServerCerts.sh
    ```
 
-4. **Update Client ID**
-   Edit `createClientCerts.sh` to set a unique `clientID` and update the `commonName` in the `.cnf` file to match the client ID (e.g., `commonName = <ClientID>`).
+ **Generate Client Certificate**
 
+   Generate the client's private key and certificate.
 
-5. **Generate Client Certificate**
-   Generate the client's private key and certificate. Make sure clientId should 12 chars or a valid MAC:
+   `client_id` must be exactly 12 characters (for example, `aabbccddeeff`):
    ```bash
-   ./createClientCerts.sh
+   ./createClientCerts.sh <client_id>
    ```
 
-6. **Transfer Server Certificate**
+ **Transfer Server Certificate**
    Transfer server certifcates:
    ```bash
    ./transfer_server_certificates.sh
    ```
 
-7. **Transfer Client Certificate**
+ **Transfer Client Certificate**
    Transfer client certifcates:
    ```bash
    ./transfer_client_certificates.sh
    ```
+   **Note:**
+   The client certificates will be placed on the device as operational.pem, operational.ca and key.pem.
+
+   If you are using a client firmware version earlier than 4.0, rename the files as follows:
+
+   - operational.pem -> cert.pem
+   - operational.ca  -> cas.pem

--- a/conf/server.cnf
+++ b/conf/server.cnf
@@ -4,7 +4,8 @@ prompt = no
 #req_extensions = req_ext
 distinguished_name = req_distinguished_name
 [ req_distinguished_name ]
-commonName = *.routerarchitects.com
+#Replace example.com with your real domain (e.g., yourdomain.com)
+commonName = example.com
 
 [ req_ext ]
 basicConstraints = CA:FALSE

--- a/transfer_client_certificates.sh
+++ b/transfer_client_certificates.sh
@@ -49,8 +49,8 @@ copy_file() {
 # Combine Root CA and Issuer CA into clientcas.pem
 cat "$SOURCE_PATH/RootCA/certs/cacert.pem" "$SOURCE_PATH/issuer/certs/issuer-cert.pem" > /tmp/clientcas.pem
 # Copy combined file to the destination
-copy_file "/tmp/clientcas.pem" "$DEST_PATH/cas.pem"
-copy_file "$SOURCE_PATH/cert_gen/certs/client-cert-${CLIENT_ID}.pem" "$DEST_PATH/cert.pem"
+copy_file "/tmp/clientcas.pem" "$DEST_PATH/operational.ca"
+copy_file "$SOURCE_PATH/cert_gen/certs/client-cert-${CLIENT_ID}.pem" "$DEST_PATH/operational.pem"
 copy_file "$SOURCE_PATH/cert_gen/private/client-private-${CLIENT_ID}.pem" "$DEST_PATH/key.pem"
 
 echo "✅ Certificates for client ID $CLIENT_ID have been successfully transferred to $DEST_PATH."


### PR DESCRIPTION
**Documentation**
- Improved README to provide clearer certificate generation steps and configuration guidance.
- Replaced the server certificate commonName with a safe generic placeholder for public repository usage.
- Updated client certificate transfer script to use operational.pem and operational.ca naming convention.

Closes #3 
