### PR TITLE
Added ACS key support for server certificate transfer

### DIFF
--- a/transfer_server_certificates.sh
+++ b/transfer_server_certificates.sh
@@ -1,10 +1,35 @@
 #!/bin/bash
 
 # Usage information
-if [ "$#" -lt 1 ]; then
+print_usage() {
   echo "Usage: $0 <destination_path>"
+  echo "Usage: $0 -i <pem_file> <destination_path>"
   echo "Example (Remote Copy): $0 taruna@200.20.20.113:~/Downloads/certs"
+  echo "Example (EC2 Remote):  $0 -i </path/to/acs-key.pem> ubuntu@<PUBLIC_DOMAIN_NAME>:/home/ubuntu/openwifi-sdk/mango-cloud-deployment/docker-compose/certs"
   echo "Example (Local Copy):  $0 /home/taruna/OpenWiFi_workspace/wlan-cloud-ucentral-deploy/docker-compose/certs"
+}
+
+# Optional ssh/scp identity file
+PEM_FILE=""
+while getopts ":i:" opt; do
+  case $opt in
+    i)
+      PEM_FILE=$OPTARG
+      ;;
+    \?)
+      print_usage
+      exit 1
+      ;;
+    :)
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ "$#" -lt 1 ]; then
+  print_usage
   exit 1
 fi
 
@@ -21,6 +46,14 @@ else
   IS_REMOTE=false
 fi
 
+# Validate identity file when provided
+if [ -n "$PEM_FILE" ]; then
+  if [ ! -f "$PEM_FILE" ]; then
+    echo "❌ Error: PEM file not found -> $PEM_FILE"
+    exit 1
+  fi
+fi
+
 # Function to check if a file exists before copying
 copy_file() {
   local src=$1
@@ -32,7 +65,11 @@ copy_file() {
   fi
 
   if $IS_REMOTE; then
-    scp "$src" "$dest"
+    if [ -n "$PEM_FILE" ]; then
+      scp -i "$PEM_FILE" "$src" "$dest"
+    else
+      scp "$src" "$dest"
+    fi
   else
     cp "$src" "$dest"
   fi
@@ -56,4 +93,3 @@ copy_file "$SOURCE_PATH/cert_gen/certs/server-cert.pem" "$DEST_PATH/websocket-ce
 copy_file "$SOURCE_PATH/cert_gen/private/server-private.pem" "$DEST_PATH/websocket-key.pem"
 
 echo "✅ Successfully copied the server certificates!"
-


### PR DESCRIPTION
#6 
**Summary**
This PR updates the certificate transfer script to support an optional SSH key (-i option). This allows secure file transfer to remote servers like EC2 while keeping existing functionality unchanged.

**Changes Made**

- Added -i <pem_file> option to pass SSH identity file
- Added validation to check if the PEM file exists
- Updated scp command to use the key when provided
- Improved usage examples in the script

**Benefits**

- Works with both password and key-based SSH
- Useful for cloud servers (like EC2)
- No impact on existing usage
- Better error handling for missing key file

**Output Screenshot**
<img width="1911" height="651" alt="Screenshot from 2026-03-24 15-37-43" src="https://github.com/user-attachments/assets/876020b2-4f53-4aec-a7ce-43d7ba2479f4" />